### PR TITLE
feat: add officer details in telegram message after auth

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -82,9 +82,9 @@ export class AuthController {
     if (authDetails.status === SgidAuthStatus.AUTHENTICATED_PUBLIC_OFFICER) {
       const verifiedMessage = authDetails.poDetails.map((object) => {
         return `You are verified with the following details: 
-        \nAgency: ${object.agency_name}
-        \nDepartment: ${object.department_name}
-        \nTitle: ${object.employment_title}`;
+        Agency: ${object.agency_name}
+        Department: ${object.department_name}
+        Title: ${object.employment_title}`;
       });
       await this.bot.telegram.sendMessage(
         chatId,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -72,19 +72,25 @@ export class AuthController {
       );
     }
 
-    const authStatus = await this.authService.verifyUserFromAuthCode({
+    const authDetails = await this.authService.verifyUserFromAuthCode({
       code,
       nonce: cookieInstance.nonce,
       codeVerifier: cookieInstance.codeVerifier,
     });
 
     // TODO - Have the bot send different messages depending on outcome
-    if (authStatus === SgidAuthStatus.AUTHENTICATED_PUBLIC_OFFICER) {
+    if (authDetails.status === SgidAuthStatus.AUTHENTICATED_PUBLIC_OFFICER) {
+      const verifiedMessage = authDetails.poDetails.map((object) => {
+        return `You are verified with the following details: 
+        \nAgency: ${object.agency_name}
+        \nDepartment: ${object.department_name}
+        \nTitle: ${object.employment_title}`;
+      });
       await this.bot.telegram.sendMessage(
         chatId,
-        'Authenticated Public Officer',
+        `Authenticated Public Officer\n\n${verifiedMessage}`, // would be nice to have Welcome ${name}
       );
-    } else if (authStatus === SgidAuthStatus.AUTHENTICATED_USER) {
+    } else if (authDetails.status === SgidAuthStatus.AUTHENTICATED_USER) {
       await this.bot.telegram.sendMessage(
         chatId,
         'Authenticated, but not Public Officer',

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -88,7 +88,7 @@ export class AuthController {
       });
       await this.bot.telegram.sendMessage(
         chatId,
-        `Authenticated Public Officer\n\n${verifiedMessage}`, // would be nice to have Welcome ${name}
+        `Authenticated Public Officer\n\n${verifiedMessage}`,
       );
     } else if (authDetails.status === SgidAuthStatus.AUTHENTICATED_USER) {
       await this.bot.telegram.sendMessage(

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -67,7 +67,7 @@ export class AuthService {
     code: string;
     codeVerifier: string;
     nonce: string;
-  }): Promise<SgidAuthStatus> {
+  }): Promise<{ status: SgidAuthStatus; poDetails?: PublicOfficerDetails[] }> {
     const { accessToken, sub } = await this.sgidClient.callback({
       code,
       codeVerifier,
@@ -80,11 +80,11 @@ export class AuthService {
       const poDetails: PublicOfficerDetails[] = JSON.parse(rawPoDetails);
 
       if (!poDetails || poDetails.length === 0) {
-        return SgidAuthStatus.AUTHENTICATED_USER;
+        return { status: SgidAuthStatus.AUTHENTICATED_USER };
       }
-      return SgidAuthStatus.AUTHENTICATED_PUBLIC_OFFICER;
+      return { status: SgidAuthStatus.AUTHENTICATED_PUBLIC_OFFICER, poDetails };
     } catch (err) {
-      return SgidAuthStatus.NOT_AUTHENTICATED;
+      return { status: SgidAuthStatus.NOT_AUTHENTICATED };
     }
   }
 }


### PR DESCRIPTION
## Problem

To verify specific details about an authenticated officer so that members are able to verify someone joining a particular telegram chatgroup is indeed from their agency/ department.

## Solution

Obtained agency name, department and title from Public Officer details from SGID to be displayed within the verification message after a public officer has been verified to join the telegram chat.

**Features**:

<img src="https://github.com/opengovsg/telegovsg/assets/89055608/9c8a9dc8-185f-4826-8ef6-4dd311c10c4d" width="350" height="350">

